### PR TITLE
Add test dependencies to support running the example from the documentation

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -20,6 +20,9 @@
   <depend>rclcpp_lifecycle</depend>
   <depend>sensor_msgs</depend>
 
+  <test_depend>joint_state_broadcaster</test_depend>
+  <test_depend>position_controllers</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>


### PR DESCRIPTION
Just adding joint_state_broadcaster and position_controllers as test dependencies to support running [this line](https://github.com/NASA-JSC-Robotics/mujoco_ros2_simulation/blob/29c7f9102636bda6b5e186831134ee41a839472f/README.md?plain=1#L229) in the docs.