### PR TITLE
Updates to support certain effort controlled robots

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,8 +8,8 @@ endif()
 
 # find dependencies
 find_package(ament_cmake REQUIRED)
-find_package(control_toolbox REQUIRED)
 find_package(controller_manager REQUIRED)
+find_package(Eigen3 REQUIRED)
 find_package(glfw3 REQUIRED)
 find_package(hardware_interface REQUIRED)
 find_package(joint_limits REQUIRED)
@@ -110,7 +110,6 @@ add_library(mujoco_ros2_simulation SHARED
     src/mujoco_lidar.cpp
 )
 ament_target_dependencies(mujoco_ros2_simulation
-  control_toolbox
   controller_manager
   hardware_interface
   pluginlib
@@ -121,6 +120,7 @@ ament_target_dependencies(mujoco_ros2_simulation
 target_link_libraries(mujoco_ros2_simulation
   ${MUJOCO_LIB}
   mujoco::libsimulate
+  Eigen3::Eigen
   Threads::Threads
   lodepng
   glfw

--- a/README.md
+++ b/README.md
@@ -74,8 +74,12 @@ Just specify the plugin and point to a valid MJCF on launch:
 ### Joints
 
 Joints in the ros2_control interface are mapped to actuators defined in the MJCF.
-For now, we rely on Mujoco's PD level joint control for position and velocity command interfaces, and write directly to `qfrc_applied` for effort command interfaces.
+For now, we rely on Mujoco's PD level `ctrl` input for all actuator control.
 Refer to Mujoco's [actuation model](https://mujoco.readthedocs.io/en/stable/computation/index.html#geactuation) for more information.
+Of note, only one type of actuator per-joint can be controllable at a time, and the type CANNOT be switched during runtime (ie, switching from position to effort control is not supported).
+Users are required to manually adjust actuator types and command interfaces to ensure that they are compatible.
+
+For example a position controlled joint on the mujoco
 
 ```xml
   <actuator>
@@ -83,13 +87,12 @@ Refer to Mujoco's [actuation model](https://mujoco.readthedocs.io/en/stable/comp
   </actuator>
 ```
 
-From there, joints can be configured with position, velocity, and effort command and state interfaces.
-Initial values can be
-For example,
+Could map to the following hardware interface:
 
 ```xml
-  <joint name="join1">
+  <joint name="joint1">
     <command_interface name="position"/>
+    <!-- Initial values for state interfaces can be specified, but default to 0 if they are not. -->
     <state_interface name="position">
       <param name="initial_value">0.0</param>
     </state_interface>
@@ -97,6 +100,8 @@ For example,
     <state_interface name="effort"/>
   </joint>
 ```
+
+Switching actuator/control types on the fly is an [open issue](#13).
 
 ### Sensors
 

--- a/include/mujoco_ros2_simulation/data.hpp
+++ b/include/mujoco_ros2_simulation/data.hpp
@@ -19,11 +19,12 @@
 
 #pragma once
 
-#include <Eigen/Dense>
+#include <Eigen/Core>
+#include <Eigen/Geometry>
+
 #include <string>
 #include <vector>
 
-#include <control_toolbox/pid.hpp>
 #include <joint_limits/joint_limits.hpp>
 
 namespace mujoco_ros2_simulation
@@ -41,15 +42,6 @@ struct JointState
   double position_command;
   double velocity_command;
   double effort_command;
-  double min_position_command;
-  double max_position_command;
-  double min_velocity_command;
-  double max_velocity_command;
-  double min_effort_command;
-  double max_effort_command;
-  control_toolbox::Pid position_pid;
-  control_toolbox::Pid velocity_pid;
-  bool is_pid_enabled{ false };
   joint_limits::JointLimits joint_limits;
   bool is_mimic{ false };
   int mimicked_joint_index;

--- a/include/mujoco_ros2_simulation/data.hpp
+++ b/include/mujoco_ros2_simulation/data.hpp
@@ -49,9 +49,6 @@ struct JointState
   double max_effort_command;
   control_toolbox::Pid position_pid;
   control_toolbox::Pid velocity_pid;
-  bool is_position_control_enabled{ false };
-  bool is_velocity_control_enabled{ false };
-  bool is_effort_control_enabled{ false };
   bool is_pid_enabled{ false };
   joint_limits::JointLimits joint_limits;
   bool is_mimic{ false };
@@ -61,6 +58,12 @@ struct JointState
   int mj_pos_adr;
   int mj_vel_adr;
   int mj_actuator_id;
+
+  // Booleans record whether or not we should be writing commands to these interfaces
+  // based on if they have been claimed.
+  bool is_position_control_enabled{ false };
+  bool is_velocity_control_enabled{ false };
+  bool is_effort_control_enabled{ false };
 };
 
 template <typename T>

--- a/include/mujoco_ros2_simulation/data.hpp
+++ b/include/mujoco_ros2_simulation/data.hpp
@@ -84,6 +84,11 @@ struct IMUSensorData
   SensorData<Eigen::Quaternion<double>> orientation;
   SensorData<Eigen::Vector3d> angular_velocity;
   SensorData<Eigen::Vector3d> linear_acceleration;
+
+  // These are currently unused but added to support controllers that require them.
+  std::vector<double> orientation_covariance;
+  std::vector<double> angular_velocity_covariance;
+  std::vector<double> linear_acceleration_covariance;
 };
 
 }  // namespace mujoco_ros2_simulation

--- a/include/mujoco_ros2_simulation/mujoco_system_interface.hpp
+++ b/include/mujoco_ros2_simulation/mujoco_system_interface.hpp
@@ -67,6 +67,9 @@ public:
   hardware_interface::CallbackReturn on_activate(const rclcpp_lifecycle::State& previous_state) override;
   hardware_interface::CallbackReturn on_deactivate(const rclcpp_lifecycle::State& previous_state) override;
 
+  hardware_interface::return_type perform_command_mode_switch(const std::vector<std::string>& start_interfaces,
+                                                              const std::vector<std::string>& stop_interfaces) override;
+
   hardware_interface::return_type read(const rclcpp::Time& time, const rclcpp::Duration& period) override;
   hardware_interface::return_type write(const rclcpp::Time& time, const rclcpp::Duration& period) override;
 

--- a/package.xml
+++ b/package.xml
@@ -10,7 +10,6 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <depend>control_toolbox</depend>
   <depend>controller_manager</depend>
   <depend>hardware_interface</depend>
   <depend>joint_limits</depend>

--- a/src/mujoco_system_interface.cpp
+++ b/src/mujoco_system_interface.cpp
@@ -744,7 +744,7 @@ hardware_interface::return_type MujocoSystemInterface::read(const rclcpp::Time& 
   {
     joint_state.position = mj_data_->qpos[joint_state.mj_pos_adr];
     joint_state.velocity = mj_data_->qvel[joint_state.mj_vel_adr];
-    joint_state.effort = mj_data_->actuator_force[joint_state.mj_vel_adr];
+    joint_state.effort = mj_data_->qfrc_actuator[joint_state.mj_vel_adr];
   }
 
   // IMU Sensor data
@@ -805,22 +805,14 @@ hardware_interface::return_type MujocoSystemInterface::write(const rclcpp::Time&
     if (joint_state.is_position_control_enabled)
     {
       mj_data_->ctrl[joint_state.mj_actuator_id] = joint_state.position_command;
-      mj_data_->qfrc_applied[joint_state.mj_vel_adr] = 0.0;
     }
     else if (joint_state.is_velocity_control_enabled)
     {
       mj_data_->ctrl[joint_state.mj_actuator_id] = joint_state.velocity_command;
-      mj_data_->qfrc_applied[joint_state.mj_vel_adr] = 0.0;
     }
     else if (joint_state.is_effort_control_enabled)
     {
-      // TODO: How can we clear the ctrl?
-      mj_data_->qfrc_applied[joint_state.mj_vel_adr] = joint_state.effort_command;
-    }
-    else
-    {
-      // Otherwise no control is enabled so we just tell the actuator to hold its current pose
-      mj_data_->ctrl[joint_state.mj_actuator_id] = joint_state.position;
+      mj_data_->ctrl[joint_state.mj_actuator_id] = joint_state.effort_command;
     }
   }
 

--- a/src/mujoco_system_interface.cpp
+++ b/src/mujoco_system_interface.cpp
@@ -728,11 +728,9 @@ hardware_interface::return_type MujocoSystemInterface::write(const rclcpp::Time&
       double min_eff, max_eff;
       min_eff = joint_state.joint_limits.has_effort_limits ? -1 * joint_state.joint_limits.max_effort :
                                                              std::numeric_limits<double>::lowest();
-      min_eff = std::max(min_eff, joint_state.min_effort_command);
 
       max_eff = joint_state.joint_limits.has_effort_limits ? joint_state.joint_limits.max_effort :
                                                              std::numeric_limits<double>::max();
-      max_eff = std::min(max_eff, joint_state.max_effort_command);
 
       mj_data_->qfrc_applied[joint_state.mj_vel_adr] = clamp(joint_state.effort_command, min_eff, max_eff);
     }

--- a/src/mujoco_system_interface.cpp
+++ b/src/mujoco_system_interface.cpp
@@ -556,6 +556,35 @@ std::vector<hardware_interface::StateInterface> MujocoSystemInterface::export_st
         {
           new_state_interfaces.emplace_back(sensor.name, state_if.name, &sensor.linear_acceleration.data.z());
         }
+        // Add covariance interfaces
+        // TODO: Is there mujoco covariance data we could use?
+        else if (state_if.name.find("orientation_covariance") == 0)
+        {
+          // Convert the index from the end of the string, this doesn't really matter yet
+          size_t idx = std::stoul(state_if.name.substr(23));
+          if (idx < sensor.orientation_covariance.size())
+          {
+            new_state_interfaces.emplace_back(sensor.name, state_if.name, &sensor.orientation_covariance[idx]);
+          }
+        }
+        else if (state_if.name.find("angular_velocity_covariance") == 0)
+        {
+          // Convert the index from the end of the string, this doesn't really matter yet
+          size_t idx = std::stoul(state_if.name.substr(28));
+          if (idx < sensor.angular_velocity_covariance.size())
+          {
+            new_state_interfaces.emplace_back(sensor.name, state_if.name, &sensor.angular_velocity_covariance[idx]);
+          }
+        }
+        else if (state_if.name.find("linear_acceleration_covariance") == 0)
+        {
+          // Convert the index from the end of the string, this doesn't really matter yet
+          size_t idx = std::stoul(state_if.name.substr(31));
+          if (idx < sensor.linear_acceleration_covariance.size())
+          {
+            new_state_interfaces.emplace_back(sensor.name, state_if.name, &sensor.linear_acceleration_covariance[idx]);
+          }
+        }
       }
     }
   }
@@ -903,6 +932,11 @@ void MujocoSystemInterface::register_sensors(const hardware_interface::HardwareI
       sensor_data.orientation.name = mujoco_sensor_name + "_quat";
       sensor_data.angular_velocity.name = mujoco_sensor_name + "_gyro";
       sensor_data.linear_acceleration.name = mujoco_sensor_name + "_accel";
+
+      // Initialize to all zeros as we do not use these yet.
+      sensor_data.orientation_covariance.resize(9, 0.0);
+      sensor_data.angular_velocity_covariance.resize(9, 0.0);
+      sensor_data.linear_acceleration_covariance.resize(9, 0.0);
 
       int quat_id = mj_name2id(mj_model_, mjOBJ_SENSOR, sensor_data.orientation.name.c_str());
       int gyro_id = mj_name2id(mj_model_, mjOBJ_SENSOR, sensor_data.angular_velocity.name.c_str());


### PR DESCRIPTION
Valkyrie, in particular.

I found some issues with the state and command interfaces that needed to be resolved. And we still had the holdover from the effort ctrl interface from the upstream, which was incorrect. This PR addresses that.

Furthermore, we should also enforce a rule that only one command interface at a time can be active, because otherwise things break because commands are written to all of them. Ultimately we should provide a way to map [actuator group states](https://mujoco.readthedocs.io/en/stable/modeling.html#group-disable) to control interfaces... But I think that's a [TBD](https://github.com/NASA-JSC-Robotics/mujoco_ros2_simulation/issues/13).

For now we have the assumption that there is only one actuator per joint available, and it is set at simulation start time.