### PR TITLE
using sensor_adr instead of sensor number for lidar data

### DIFF
--- a/src/mujoco_lidar.cpp
+++ b/src/mujoco_lidar.cpp
@@ -193,7 +193,7 @@ bool MujocoLidar::register_lidar(const hardware_interface::HardwareInfo& hardwar
 
     // Add this range to the sensor finders data array. There's technically no guarantee that the data is
     // sequential so we're just tracking this directly.
-    lidar_it->sensor_indexes[idx] = i;
+    lidar_it->sensor_indexes[idx] = mj_model_->sensor_adr[i];
   }
 
   // TODO: Verify that everything actually got filled in correctly...


### PR DESCRIPTION
The correct item to use for indexing sensor data is `sensor_adr`, rather than sensor number. Some sensors, like FTS and IMU have > 1 length, so they increment the `sensor_adr` multiple times. Using `mj_model_->sensor_adr[sensor_num]` isntead of `sensor_num`  resolves this.