### PR TITLE
Fix to enable tendon actuators  

### DIFF
--- a/src/mujoco_system_interface.cpp
+++ b/src/mujoco_system_interface.cpp
@@ -851,6 +851,11 @@ void MujocoSystemInterface::register_joints(const hardware_interface::HardwareIn
         break;
       }
     }
+
+    // Is no mapping was found, try fallback to looking for an actuator with the same name as the joint
+    mujoco_actuator_id = mujoco_actuator_id == -1 ? mj_name2id(mj_model_, mjtObj::mjOBJ_ACTUATOR, joint.name.c_str()) :
+                                                    mujoco_actuator_id;
+
     if (mujoco_actuator_id == -1)
     {
       // This isn't a failure the joint just won't be controllable


### PR DESCRIPTION
I tried using this to simulate a robot with a Robotiq  gripper and ran into some issues.  

~~First, there seems to be a logic error limits are not specified and effort based control is used. The bounds in the `JointLimits` structure are never initialized even though they are used in the `write` method. I added some defaults that fix the problem. I'm not sure the structure needs the boolean flags, e.g. `has_effort_limits` in the first place, since we can just set a limit of the max possible values as defaults.~~

Secondly, the strategy to find the actuator to joint mapping does not work for tendon types. This is a problem because the Robotiq MJCF model uses an actuator on a tendon. The "fix" here is to require the actuator be named the same as the joint. This make the mapping unambiguous. However, it does change the behavior. The README provides an example that already does that,so at least it is not totally unexpected.
