### PR TITLE
Disable rangefinder visual at startup

### DIFF
--- a/src/mujoco_system_interface.cpp
+++ b/src/mujoco_system_interface.cpp
@@ -431,8 +431,7 @@ hardware_interface::CallbackReturn MujocoSystemInterface::on_init(const hardware
 
   // Disable the rangefinder flag at startup so that we don't get the yellow lines.
   // We can still turn this on manually if desired.
-  auto rangefinder_flag_ptr = sim_->opt.flags + mjVIS_RANGEFINDER;
-  *rangefinder_flag_ptr = false;
+  sim_->opt.flags[mjVIS_RANGEFINDER] = false;
 
   // When the interface is activated, we start the physics engine.
   physics_thread_ = std::thread([this]() {

--- a/src/mujoco_system_interface.cpp
+++ b/src/mujoco_system_interface.cpp
@@ -429,6 +429,11 @@ hardware_interface::CallbackReturn MujocoSystemInterface::on_init(const hardware
     return hardware_interface::CallbackReturn::FAILURE;
   }
 
+  // Disable the rangefinder flag at startup so that we don't get the yellow lines.
+  // We can still turn this on manually if desired.
+  auto rangefinder_flag_ptr = sim_->opt.flags + mjVIS_RANGEFINDER;
+  *rangefinder_flag_ptr = false;
+
   // When the interface is activated, we start the physics engine.
   physics_thread_ = std::thread([this]() {
     // Load the simulation and do an initial forward pass


### PR DESCRIPTION
This PR sets the flag for the rangefinder visuals to be false at startup. The visuals are pretty distracting, and can still be turned on if desired after startup. This changes the startup visual from something like this
<img width="1266" height="825" alt="image" src="https://github.com/user-attachments/assets/a8faa2c6-4ce0-40f0-92af-b7b8fecbf57e" />
To something like this
<img width="1189" height="729" alt="image" src="https://github.com/user-attachments/assets/a1c2b951-c977-4c81-9d5a-f6b418425a9f" />

