### PR TITLE
Prioritize the environment's Mujoco install location

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,24 +19,72 @@ find_package(Threads REQUIRED)
 
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
-find_package(mujoco QUIET)
-if(mujoco_FOUND)
-  message(STATUS "Mujoco build from source has been found")
-  set(MUJOCO_LIB mujoco::mujoco)
-  set(MUJOCO_INCLUDE_DIR ${MUJOCO_INCLUDE_DIR})
-  set(MUJOCO_SIMULATE_DIR ${MUJOCO_INCLUDE_DIR}/../simulate)
-elseif(DEFINED ENV{MUJOCO_DIR})
-  message(STATUS "Mujoco build from source has not been found. Attempting to find the binary in $ENV{MUJOCO_DIR} instead.")
-  find_library(MUJOCO_LIB mujoco HINTS $ENV{MUJOCO_DIR}/lib)
-  if(NOT MUJOCO_LIB)
+# Attempt to find an install of mujoco, either the library itself, from the environment, or
+# as a last resort download the required tar file manually and unzip it into the workspace.
+if(DEFINED ENV{MUJOCO_DIR})
+  message(STATUS "Building find the binary from: $ENV{MUJOCO_DIR}.")
+  set(MUJOCO_DIR $ENV{MUJOCO_DIR})
+  set(MUJOCO_LIB "$ENV{MUJOCO_DIR}/lib/libmujoco.so")
+  if(NOT EXISTS ${MUJOCO_LIB})
     message(FATAL_ERROR "Failed to find binary in $ENV{MUJOCO_DIR}")
   endif()
   set(MUJOCO_INCLUDE_DIR $ENV{MUJOCO_DIR}/include)
   set(MUJOCO_SIMULATE_DIR $ENV{MUJOCO_DIR}/simulate)
 else()
-  message(FATAL_ERROR "Failed to find mujoco with find_package.
-  Either build and install mujoco from source or set the MUJOCO_DIR environment variable to tell CMake where to find the binary install. ")
+  find_package(mujoco QUIET)
+  if (mujoco_FOUND)
+    message(STATUS "No Mujoco install location specified, but found Mujoco source build.")
+    set(MUJOCO_LIB mujoco::mujoco)
+    set(MUJOCO_INCLUDE_DIR ${MUJOCO_INCLUDE_DIR})
+    set(MUJOCO_SIMULATE_DIR ${MUJOCO_INCLUDE_DIR}/../simulate)
+  endif()
 endif()
+
+if (NOT DEFINED MUJOCO_INCLUDE_DIR)
+  # As a last resort attempt to install by downloading the hardcoded version of MuJoCo.
+  include(FetchContent)
+
+  # Detect architecture
+  set(MUJOCO_VERSION "3.3.4")
+  if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|AMD64")
+    set(CPU_ARCH "x86_64")
+  elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64")
+    set(CPU_ARCH "aarch64")
+  else()
+    message(FATAL_ERROR "Unsupported architecture: ${CMAKE_SYSTEM_PROCESSOR}")
+  endif()
+
+  message(STATUS "No MuJoCo installation found. Downloading MuJoCo ${MUJOCO_VERSION} for ${CPU_ARCH}.")
+
+  # Download the archive and put it next to the source directory
+  set(MUJOCO_DOWNLOAD_DIR ${CMAKE_CURRENT_SOURCE_DIR}/mujoco)
+  set(MUJOCO_EXTRACT_DIR ${MUJOCO_DOWNLOAD_DIR}/mujoco-${MUJOCO_VERSION})
+  set(FETCHCONTENT_UPDATES_DISCONNECTED ON)
+  FetchContent_Declare(
+    mujoco_download
+    URL https://github.com/google-deepmind/mujoco/releases/download/${MUJOCO_VERSION}/mujoco-${MUJOCO_VERSION}-linux-${CPU_ARCH}.tar.gz
+    SOURCE_DIR ${MUJOCO_EXTRACT_DIR}
+    DOWNLOAD_EXTRACT_TIMESTAMP True
+  )
+  FetchContent_MakeAvailable(mujoco_download)
+
+  set(MUJOCO_DIR ${MUJOCO_EXTRACT_DIR})
+  message(STATUS "MuJoCo downloaded to: ${MUJOCO_DIR}")
+
+  # Find the library in the downloaded location
+  find_library(MUJOCO_LIB mujoco HINTS ${MUJOCO_DIR}/lib NO_DEFAULT_PATH)
+  if(NOT MUJOCO_LIB)
+    message(FATAL_ERROR "Failed to find MuJoCo library in ${MUJOCO_DIR}/lib")
+  endif()
+
+  set(MUJOCO_INCLUDE_DIR ${MUJOCO_DIR}/include)
+  set(MUJOCO_SIMULATE_DIR ${MUJOCO_DIR}/simulate)
+  message(STATUS "MuJoCo library found: ${MUJOCO_LIB}")
+endif()
+
+# Note which install we are using
+message(STATUS "Using MuJoCo library: ${MUJOCO_LIB}")
+message(STATUS "Using MuJoCo include dir: ${MUJOCO_INCLUDE_DIR}")
 
 # Fetch lodepng dependency.
 if(NOT TARGET lodepng)

--- a/README.md
+++ b/README.md
@@ -13,15 +13,16 @@ Parts of this library are also based on the MoveIt [mujoco_ros2_control](https:/
 This interface has only been tested against ROS 2 humble and MuJoCo `3.3.4`.
 We assume all required ROS dependencies have been installed either manually or with `rosdep`.
 
-A local install of MuJoCo is required to build the application, this package will not handle it for you.
-Refer to their documentation for installation procedures.
-
-Once installed, set the following environment variables:
+An install of MuJoCo is required to build the application.
+To specify a locally installed version, set the environment variables:
 
 ```bash
+# Assuming it was installed in this location
 MUJOCO_VERSION=3.3.4
-MUJOCO_DIR=/opt/mujoco/mujoco-3.3.4
+MUJOCO_DIR="/opt/mujoco/mujoco-${MUJOCO_VERSION}"
 ```
+
+If a local install is not found, this package will download the required version at runtime, though this requires a network connection.
 
 From there the library can be compiled with `colcon build ...`, as normal.
 


### PR DESCRIPTION
The way things are currently setup in the build CMake will try to use any existing mujoco install it finds on disk. This makes it impossible to build the drivers if the environment's installed version is incompatible with what we are assuming is 3.3.4. I just reordered the priorities so that if `MUJOCO_DIR` is set, it will use it by default, otherwise it will try an existing install. If neither of those is found, then as a last resort it will download the required artifact a build time.

Not sure if this is the most intuitive approach... Maybe we should just always download the version we expect, as it's not like the mujoco library is particularly heavy.