### PR TITLE
Ensure the cameras context will support the maximum camera resolutions

### DIFF
--- a/test/test_resources/test_robot.xml
+++ b/test/test_resources/test_robot.xml
@@ -17,7 +17,7 @@
         <site name="camera_color_frame" pos="1.0 0 0.1" quat="1.0 0 0 0"/>
         <site name="camera_color_optical_frame" pos="1.0 0 0.1" quat="-0.49999816339744824 0.4999999999966268 0.5000018366025517 -0.4999999999966268"/>
         <site name="camera_color_mujoco_frame" pos="1.0 0 0.1" quat="0.5000006633911983 0.4999974999995599 0.49999933659630164 0.5000024999995599"/>
-        <camera name="camera" fovy="58" mode="fixed" resolution="640 480" pos="1.0 0 0.1" quat="-0.4999999999966268 -0.49999816339744824 -0.4999999999966268 -0.5000018366025517"/>
+        <camera name="camera" fovy="58" mode="fixed" resolution="1280 720" pos="1.0 0 0.1" quat="-0.4999999999966268 -0.49999816339744824 -0.4999999999966268 -0.5000018366025517"/>
       </body>
       <geom size="0.5 0.05 0.05" pos="0.5 0 0" type="box" class="collision"/>
       <geom size="0.5 0.05 0.05" pos="0.5 0 0" type="box" rgba="1 0 0 1" class="visual"/>


### PR DESCRIPTION
As @ndunkelb-nasa the default size for these contexts is [640x480](https://mujoco.readthedocs.io/en/stable/XMLreference.html#visual-global).

This change adjust's the contexts size before starting camera rendering to ensure it will contain the maximum width and height of all images. 

Before:

<img width="710" height="395" alt="image" src="https://github.com/user-attachments/assets/f9d5c515-9d8a-4c86-8674-5894ab99de4f" />

After:

<img width="687" height="415" alt="image" src="https://github.com/user-attachments/assets/9a3de287-1b7a-4704-9d8f-104420b8c6e7" />

