### PR TITLE
Add `mujoco_vendor` integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,11 +23,6 @@ set(MUJOCO_LIB mujoco::mujoco)
 get_target_property(MUJOCO_INCLUDE_DIR mujoco::mujoco INTERFACE_INCLUDE_DIRECTORIES)
 set(MUJOCO_SIMULATE_DIR ${MUJOCO_INCLUDE_DIR}/../simulate)
 
-message(STATUS "Using MuJoCo from vendor package")
-message(STATUS "  MUJOCO_INCLUDE_DIR: ${MUJOCO_INCLUDE_DIR}")
-message(STATUS "  MUJOCO_SIMULATE_DIR: ${MUJOCO_SIMULATE_DIR}")
-
-
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 # Fetch lodepng dependency.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,13 +17,13 @@ find_package(rclcpp REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)
 find_package(Threads REQUIRED)
 
-# Import MuJoCo via vendor package (already installed)
-find_package(mujoco_vendor REQUIRED)
+# Attempt to link MuJoCo via the vendor package, if available
+find_package(mujoco_vendor QUIET)
 if(mujoco_vendor_FOUND)
   set(MUJOCO_LIB mujoco::mujoco)
   set(MUJOCO_INCLUDE_DIR ${mujoco_vendor_INCLUDE_DIRS})
   set(MUJOCO_SIMULATE_DIR ${MUJOCO_INCLUDE_DIR}/../simulate)
-
+# If the user has specified a MuJoCo install location use it
 elseif(DEFINED ENV{MUJOCO_INSTALL_DIR})
   message(STATUS "Mujoco build from source has not been found. Attempting to find the binary in $ENV{MUJOCO_INSTALL_DIR} instead.")
   set(MUJOCO_DIR $ENV{MUJOCO_INSTALL_DIR})
@@ -33,9 +33,10 @@ elseif(DEFINED ENV{MUJOCO_INSTALL_DIR})
   endif()
   set(MUJOCO_INCLUDE_DIR $ENV{MUJOCO_DIR}/include)
   set(MUJOCO_SIMULATE_DIR $ENV{MUJOCO_DIR}/simulate)
+# Otherwise we fallback and download the required tarfile and install it manually
 else()
   include(FetchContent)
-    # Detect architecture
+  # Detect architecture
   set(MUJOCO_VERSION "3.3.4")
   if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|AMD64")
     set(CPU_ARCH "x86_64")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,10 +18,61 @@ find_package(rclcpp_lifecycle REQUIRED)
 find_package(Threads REQUIRED)
 
 # Import MuJoCo via vendor package (already installed)
-find_package(mujoco REQUIRED)
-set(MUJOCO_LIB mujoco::mujoco)
-get_target_property(MUJOCO_INCLUDE_DIR mujoco::mujoco INTERFACE_INCLUDE_DIRECTORIES)
-set(MUJOCO_SIMULATE_DIR ${MUJOCO_INCLUDE_DIR}/../simulate)
+find_package(mujoco_vendor REQUIRED)
+if(mujoco_vendor_FOUND)
+  set(MUJOCO_LIB mujoco::mujoco)
+  set(MUJOCO_INCLUDE_DIR ${mujoco_vendor_INCLUDE_DIRS})
+  set(MUJOCO_SIMULATE_DIR ${MUJOCO_INCLUDE_DIR}/../simulate)
+
+elseif(DEFINED ENV{MUJOCO_INSTALL_DIR})
+  message(STATUS "Mujoco build from source has not been found. Attempting to find the binary in $ENV{MUJOCO_INSTALL_DIR} instead.")
+  set(MUJOCO_DIR $ENV{MUJOCO_INSTALL_DIR})
+  find_library(MUJOCO_LIB mujoco HINTS $ENV{MUJOCO_DIR}/lib)
+  if(NOT MUJOCO_LIB)
+    message(FATAL_ERROR "Failed to find binary in $ENV{MUJOCO_DIR}")
+  endif()
+  set(MUJOCO_INCLUDE_DIR $ENV{MUJOCO_DIR}/include)
+  set(MUJOCO_SIMULATE_DIR $ENV{MUJOCO_DIR}/simulate)
+else()
+  include(FetchContent)
+    # Detect architecture
+  set(MUJOCO_VERSION "3.3.4")
+  if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|AMD64")
+    set(CPU_ARCH "x86_64")
+  elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64")
+    set(CPU_ARCH "aarch64")
+  else()
+    message(FATAL_ERROR "Unsupported architecture: ${CMAKE_SYSTEM_PROCESSOR}")
+  endif()
+
+  message(STATUS "No MuJoCo installation found. Downloading MuJoCo ${MUJOCO_VERSION} for ${CPU_ARCH}.")
+
+  # Download the archive and put it next to the source directory
+  set(MUJOCO_DOWNLOAD_DIR ${CMAKE_CURRENT_SOURCE_DIR}/mujoco)
+  set(MUJOCO_EXTRACT_DIR ${MUJOCO_DOWNLOAD_DIR}/mujoco-${MUJOCO_VERSION})
+  set(FETCHCONTENT_UPDATES_DISCONNECTED ON)
+  FetchContent_Declare(
+    mujoco_download
+    URL https://github.com/google-deepmind/mujoco/releases/download/${MUJOCO_VERSION}/mujoco-${MUJOCO_VERSION}-linux-${CPU_ARCH}.tar.gz
+    SOURCE_DIR ${MUJOCO_EXTRACT_DIR}
+    DOWNLOAD_EXTRACT_TIMESTAMP True
+  )
+  FetchContent_MakeAvailable(mujoco_download)
+
+  set(MUJOCO_DIR ${MUJOCO_EXTRACT_DIR})
+  message(STATUS "MuJoCo downloaded to: ${MUJOCO_DIR}")
+
+  # Find the library in the downloaded location
+  find_library(MUJOCO_LIB mujoco HINTS ${MUJOCO_DIR}/lib NO_DEFAULT_PATH)
+  if(NOT MUJOCO_LIB)
+    message(FATAL_ERROR "Failed to find MuJoCo library in ${MUJOCO_DIR}/lib")
+  endif()
+
+  set(MUJOCO_INCLUDE_DIR ${MUJOCO_DIR}/include)
+  set(MUJOCO_SIMULATE_DIR ${MUJOCO_DIR}/simulate)
+  message(STATUS "MuJoCo library found: ${MUJOCO_LIB}")
+endif()
+
 
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,65 +17,18 @@ find_package(rclcpp REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)
 find_package(Threads REQUIRED)
 
+# Import MuJoCo via vendor package (already installed)
+find_package(mujoco REQUIRED)
+set(MUJOCO_LIB mujoco::mujoco)
+get_target_property(MUJOCO_INCLUDE_DIR mujoco::mujoco INTERFACE_INCLUDE_DIRECTORIES)
+set(MUJOCO_SIMULATE_DIR ${MUJOCO_INCLUDE_DIR}/../simulate)
+
+message(STATUS "Using MuJoCo from vendor package")
+message(STATUS "  MUJOCO_INCLUDE_DIR: ${MUJOCO_INCLUDE_DIR}")
+message(STATUS "  MUJOCO_SIMULATE_DIR: ${MUJOCO_SIMULATE_DIR}")
+
+
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
-
-# Attempt to find an install of mujoco, either the library itself, from the environment, or
-# as a last resort download the required tar file manually and unzip it into the workspace.
-find_package(mujoco QUIET)
-if(mujoco_FOUND)
-  message(STATUS "Mujoco build from source has been found")
-  set(MUJOCO_LIB mujoco::mujoco)
-  set(MUJOCO_INCLUDE_DIR ${MUJOCO_INCLUDE_DIR})
-  set(MUJOCO_SIMULATE_DIR ${MUJOCO_INCLUDE_DIR}/../simulate)
-elseif(DEFINED ENV{MUJOCO_INSTALL_DIR})
-  message(STATUS "Mujoco build from source has not been found. Attempting to find the binary in $ENV{MUJOCO_INSTALL_DIR} instead.")
-  set(MUJOCO_DIR $ENV{MUJOCO_INSTALL_DIR})
-  find_library(MUJOCO_LIB mujoco HINTS $ENV{MUJOCO_DIR}/lib)
-  if(NOT MUJOCO_LIB)
-    message(FATAL_ERROR "Failed to find binary in $ENV{MUJOCO_DIR}")
-  endif()
-  set(MUJOCO_INCLUDE_DIR $ENV{MUJOCO_DIR}/include)
-  set(MUJOCO_SIMULATE_DIR $ENV{MUJOCO_DIR}/simulate)
-else()
-  include(FetchContent)
-
-  # Detect architecture
-  set(MUJOCO_VERSION "3.3.4")
-  if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|AMD64")
-    set(CPU_ARCH "x86_64")
-  elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64")
-    set(CPU_ARCH "aarch64")
-  else()
-    message(FATAL_ERROR "Unsupported architecture: ${CMAKE_SYSTEM_PROCESSOR}")
-  endif()
-
-  message(STATUS "No MuJoCo installation found. Downloading MuJoCo ${MUJOCO_VERSION} for ${CPU_ARCH}.")
-
-  # Download the archive and put it next to the source directory
-  set(MUJOCO_DOWNLOAD_DIR ${CMAKE_CURRENT_SOURCE_DIR}/mujoco)
-  set(MUJOCO_EXTRACT_DIR ${MUJOCO_DOWNLOAD_DIR}/mujoco-${MUJOCO_VERSION})
-  set(FETCHCONTENT_UPDATES_DISCONNECTED ON)
-  FetchContent_Declare(
-    mujoco_download
-    URL https://github.com/google-deepmind/mujoco/releases/download/${MUJOCO_VERSION}/mujoco-${MUJOCO_VERSION}-linux-${CPU_ARCH}.tar.gz
-    SOURCE_DIR ${MUJOCO_EXTRACT_DIR}
-    DOWNLOAD_EXTRACT_TIMESTAMP True
-  )
-  FetchContent_MakeAvailable(mujoco_download)
-
-  set(MUJOCO_DIR ${MUJOCO_EXTRACT_DIR})
-  message(STATUS "MuJoCo downloaded to: ${MUJOCO_DIR}")
-
-  # Find the library in the downloaded location
-  find_library(MUJOCO_LIB mujoco HINTS ${MUJOCO_DIR}/lib NO_DEFAULT_PATH)
-  if(NOT MUJOCO_LIB)
-    message(FATAL_ERROR "Failed to find MuJoCo library in ${MUJOCO_DIR}/lib")
-  endif()
-
-  set(MUJOCO_INCLUDE_DIR ${MUJOCO_DIR}/include)
-  set(MUJOCO_SIMULATE_DIR ${MUJOCO_DIR}/simulate)
-  message(STATUS "MuJoCo library found: ${MUJOCO_LIB}")
-endif()
 
 # Fetch lodepng dependency.
 if(NOT TARGET lodepng)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This interface has only been tested against ROS 2 jazzy and MuJoCo `3.3.4`.
 It should also be compatible with kilted and rolling, but we do not actively maintain those.
 We assume all required ROS dependencies have been installed either manually or with `rosdep`.
 
-For configuring MuJoCo, the included [CMakeLists.txt](./CMakeLists.txt) will first attempt to use the  [mujoco_vendor](https://github.com/pal-robotics/mujoco_vendor) package if it is installed in your workspace.
+For configuring MuJoCo, the included [CMakeLists.txt](./CMakeLists.txt) will first attempt to use the [mujoco_vendor](https://github.com/pal-robotics/mujoco_vendor) package if it is installed in your workspace.
 If it is not found, a local install of MuJoCo can be used to build the application by setting the following environment variables,
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -14,10 +14,8 @@ This interface has only been tested against ROS 2 jazzy and MuJoCo `3.3.4`.
 It should also be compatible with kilted and rolling, but we do not actively maintain those.
 We assume all required ROS dependencies have been installed either manually or with `rosdep`.
 
-For configuring MuJoCo, the included [CMakeLists.txt](./CMakeLists.txt) will download and install the tarfile automatically.
-As long as users have a good network connection there should not be an issue.
-
-However, a local install of MuJoCo can be used to build the application by setting the following environment variables,
+For configuring MuJoCo, the included [CMakeLists.txt](./CMakeLists.txt) will first attempt to use the mujoco_vendor package if it is installed in your workspace.
+If mujoco_vendor is not found, a local install of MuJoCo can be used to build the application by setting the following environment variables,
 
 ```bash
 # The tested version
@@ -26,6 +24,8 @@ MUJOCO_VERSION=3.3.4
 # Wherever it was installed and extracted on your machine
 MUJOCO_INSTALL_DIR=/opt/mujoco/mujoco-3.3.4
 ```
+If neither is available, the script will automatically download and install the MuJoCo tarfile.
+As long as users have a stable network connection, this process should complete without issues.
 
 From there the library can be compiled with `colcon build ...`, as normal.
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ This interface has only been tested against ROS 2 jazzy and MuJoCo `3.3.4`.
 It should also be compatible with kilted and rolling, but we do not actively maintain those.
 We assume all required ROS dependencies have been installed either manually or with `rosdep`.
 
-For configuring MuJoCo, the included [CMakeLists.txt](./CMakeLists.txt) will first attempt to use the mujoco_vendor package if it is installed in your workspace.
-If mujoco_vendor is not found, a local install of MuJoCo can be used to build the application by setting the following environment variables,
+For configuring MuJoCo, the included [CMakeLists.txt](./CMakeLists.txt) will first attempt to use the  [mujoco_vendor](https://github.com/pal-robotics/mujoco_vendor) package if it is installed in your workspace.
+If [mujoco_vendor] is not found, a local install of MuJoCo can be used to build the application by setting the following environment variables,
 
 ```bash
 # The tested version

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ It should also be compatible with kilted and rolling, but we do not actively mai
 We assume all required ROS dependencies have been installed either manually or with `rosdep`.
 
 For configuring MuJoCo, the included [CMakeLists.txt](./CMakeLists.txt) will first attempt to use the  [mujoco_vendor](https://github.com/pal-robotics/mujoco_vendor) package if it is installed in your workspace.
-If [mujoco_vendor] is not found, a local install of MuJoCo can be used to build the application by setting the following environment variables,
+If it is not found, a local install of MuJoCo can be used to build the application by setting the following environment variables,
 
 ```bash
 # The tested version

--- a/package.xml
+++ b/package.xml
@@ -10,6 +10,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>mujoco_vendor</depend>
   <depend>controller_manager</depend>
   <depend>hardware_interface</depend>
   <depend>libglfw3-dev</depend>

--- a/package.xml
+++ b/package.xml
@@ -17,6 +17,7 @@
   <depend>rclcpp</depend>
   <depend>rclcpp_lifecycle</depend>
   <depend>sensor_msgs</depend>
+  <depend>mujoco_vendor</depend>
 
   <test_depend>joint_state_broadcaster</test_depend>
   <test_depend>position_controllers</test_depend>

--- a/package.xml
+++ b/package.xml
@@ -10,7 +10,6 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <depend>mujoco_vendor</depend>
   <depend>controller_manager</depend>
   <depend>hardware_interface</depend>
   <depend>libglfw3-dev</depend>


### PR DESCRIPTION
We have recently added https://github.com/pal-robotics/mujoco_vendor integration. I'm waiting for this to do an official release: https://github.com/ros2-gbp/ros2-gbp-github-org/issues/895

Thanks to the work of @Ortisa